### PR TITLE
ci (release): add macOS (osx) release

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -79,6 +79,8 @@ jobs:
           RP linux-x64
           RP linux-arm
           RP linux-arm64
+          RP osx-x64
+          RP osx-arm64
 
       - name: Upload assets to Release (on release)
         if: github.event_name == 'release'

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -50,12 +50,17 @@ jobs:
             rm -rf bin
             mkdir -p bin
 
+            extra_flags="-p:PublishReadyToRun=true"
+            if [[ "$1" != osx-* ]]; then
+              extra_flags="-p:PublishReadyToRun=true"
+            fi
+
             dotnet publish -c Release -r "$1" -f net10.0 \
               --self-contained true \
               -p:PublishTrimmed=true \
               -p:AssemblyName=sshhub_"$1" \
               -p:PublishSingleFile=true \
-              -p:PublishReadyToRun=true \
+              $extra_flags \
               -p:PublishDir=bin
 
             echo "--- bin contents ($1) ---"

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -49,8 +49,7 @@ jobs:
 
             rm -rf bin
             mkdir -p bin
-
-            extra_flags="-p:PublishReadyToRun=true"
+            
             if [[ "$1" != osx-* ]]; then
               extra_flags="-p:PublishReadyToRun=true"
             fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added macOS (x64 and ARM64) as available runtime platforms for binary distribution and updated the release publishing workflow to include these targets.
  * Adjusted publishing workflow to vary packaging/publish flags based on the target runtime (macOS vs other platforms).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->