### PR TITLE
fix: Make the Enter key as unnecessary when exit

### DIFF
--- a/sshhub/Action.cs
+++ b/sshhub/Action.cs
@@ -137,7 +137,7 @@ namespace sshhub
                 Console.Write("y=Yes / Other=Cancel >> ");
 
                 ConsoleKeyInfo input = Console.ReadKey();
-                if (input != null && input.Key == ConsoleKey.Y)
+                if (input.Key == ConsoleKey.Y)
                     return true;
 
                 return false;

--- a/sshhub/Action.cs
+++ b/sshhub/Action.cs
@@ -136,8 +136,8 @@ namespace sshhub
                 Warning($"{msg}, Confirm?");
                 Console.Write("y=Yes / Other=Cancel >> ");
 
-                var input = Console.ReadLine();
-                if (input != null && input.Equals("y", StringComparison.CurrentCultureIgnoreCase))
+                ConsoleKeyInfo input = Console.ReadKey();
+                if (input != null && input.Key == ConsoleKey.Y)
                     return true;
 
                 return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confirmation input handling to require specific key press instead of text-based input, making the confirmation process more reliable and reducing potential for unintended confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->