### PR TITLE
feat: Add other options feature

### DIFF
--- a/sshhub/Action.cs
+++ b/sshhub/Action.cs
@@ -355,7 +355,8 @@ namespace sshhub
                     IP = target.IP,
                     Port = target.Port,
                     Username = target.Username,
-                    ScanOnline = target.ScanOnline
+                    ScanOnline = target.ScanOnline,
+                    Options = target.Options
                 };
 
                 while (true)

--- a/sshhub/Action.cs
+++ b/sshhub/Action.cs
@@ -569,7 +569,18 @@ namespace sshhub
 
                 string jsonText = File.ReadAllText(Program.CONFIGPATH);
 
-                return JsonSerializer.Deserialize(jsonText, ConfigJsonContext.Default.ConfigRoot) ?? new ConfigRoot();
+                var config = JsonSerializer.Deserialize(jsonText, ConfigJsonContext.Default.ConfigRoot) ?? new ConfigRoot();
+
+                // Migrate legacy Exec template that lacks {$Options} to the new default which includes {$Options}.
+                // Only migrate when the value exactly matches the known legacy default to avoid overwriting user-custom templates.
+                const string legacyExec = "ssh {$Username}@{$IP} -p {$Port}";
+                if (config.Exec != null && config.Exec.Trim().Equals(legacyExec, StringComparison.Ordinal))
+                {
+                    config.Exec = new ConfigRoot().Exec;
+                    File.WriteAllText(Program.CONFIGPATH, GetJsonFromConfig(config));
+                }
+
+                return config;
             }
 
             static string GetJsonFromConfig(ConfigRoot config)

--- a/sshhub/Action.cs
+++ b/sshhub/Action.cs
@@ -338,6 +338,10 @@ namespace sshhub
                     return null;
                 target.ScanOnline = (bool)newScanOnline;
 
+                string? newOptions = ConfigAsk.Options(target, allTargets, true);
+                if (newOptions == null)
+                    return null;
+                target.Options = newOptions;
 
                 return target;
             }
@@ -369,8 +373,9 @@ namespace sshhub
                         "\e[93m" + "$ " + $"4. Port        ({newTarget.Port})",
                         "\e[93m" + "$ " + $"5. Username    ({newTarget.Username})",
                         "\e[93m" + "$ " + $"6. ScanOnline  ({newTarget.ScanOnline})",
-                        "\e[91m" + "$ " + "7. Cancel",
-                        "\e[92m" + "$ " + "8. Save/Exit"
+                        "\e[93m" + "$ " + $"7. Options     ({newTarget.Options})",
+                        "\e[91m" + "$ " + "8. Cancel",
+                        "\e[92m" + "$ " + "9. Save/Exit"
                     ];
 
                     int selected = WriteLine.SelectableMenu(menuItems, 2, true);
@@ -428,11 +433,19 @@ namespace sshhub
                                 break;
                             }
                         case 6:
+                            {
+                                string? newOptions = ConfigAsk.Options(newTarget, allTargets, false);
+                                if (newOptions == null)
+                                    break;
+                                newTarget.Options = newOptions;
+                                break;
+                            }
+                        case 7:
                         case -1:
                             {
                                 return null;
                             }
-                        case 7:
+                        case 8:
                             {
                                 return newTarget;
                             }
@@ -532,6 +545,20 @@ namespace sshhub
                     else
                         return newScanOnline;
                 }
+
+                internal static string? Options(TargetConfig target, TargetConfig[] allTargets, bool isNew)
+                {
+                    string? newOptions = Ask.String(
+                        isNew ? "Enter Target Options" : $"Current Options ({target.Options})",
+                        checkEmpty: false
+                    );
+                    if (newOptions == null)
+                        return null;
+                    else if (newOptions != string.Empty)
+                        return newOptions;
+                    else
+                        return target.Options;
+                }
             }
 
             public static ConfigRoot ReLoad()
@@ -581,7 +608,7 @@ namespace sshhub
             foreach (var t in targets)
             {
                 Console.WriteLine(
-                    $"ID: {t.id}, Name: {t.Name}, IP: {t.IP}, Port: {t.Port}, Username: {t.Username}, ScanOnline: {t.ScanOnline}"
+                    $"ID: {t.id}, Name: {t.Name}, IP: {t.IP}, Port: {t.Port}, Username: {t.Username}, ScanOnline: {t.ScanOnline}, Other options: {t.Options}"
                 );
             }
         }

--- a/sshhub/Config.cs
+++ b/sshhub/Config.cs
@@ -2,7 +2,7 @@
 {
     public class ConfigRoot
     {
-        public string Exec { get; set; } = "ssh {$Username}@{$IP} -p {$Port}";
+        public string Exec { get; set; } = "ssh {$Username}@{$IP} -p {$Port} {$Options}";
         public TargetConfig[] Targets { get; set; } = [];
     }
 
@@ -15,5 +15,6 @@
         public int Port { get; set; } = 22;
         public string Username { get; set; } = string.Empty;
         public bool ScanOnline { get; set; } = false;
+        public string Options { get; set; } = string.Empty;
     }
 }

--- a/sshhub/Program.cs
+++ b/sshhub/Program.cs
@@ -271,7 +271,7 @@ namespace sshhub
         /// Prompt the user to edit the command template used to launch SSH and persist the updated template to the application configuration.
         /// </summary>
         /// <remarks>
-        /// Supported placeholders: {@code {$IP}}, {@code {$Port}}, {@code {$Username}}. If the user cancels the prompt (provides no input), the configuration is not changed and the method returns to the main menu.
+        /// Supported placeholders: {@code {$IP}}, {@code {$Port}}, {@code {$Username}}, {@code {$Options}}. If the user cancels the prompt (provides no input), the configuration is not changed and the method returns to the main menu.
         /// </remarks>
         static void EditExec()
         {
@@ -282,7 +282,7 @@ namespace sshhub
             Console.WriteLine("{$IP}\t\tConfigurated IP");
             Console.WriteLine("{$Port}\t\tConfigurated Port");
             Console.WriteLine("{$Username}\tConfigurated Username");
-            Console.WriteLine("{$Options}\tConfigurated other Options");
+            Console.WriteLine("{$Options}\tConfigured other options");
 
             string? input = Ask.String($"Current Exec ({Config.Exec})", checkEmpty: true);
 

--- a/sshhub/Program.cs
+++ b/sshhub/Program.cs
@@ -89,7 +89,8 @@ namespace sshhub
             string exec = Config.Exec
                 .Replace("{$IP}", target.IP)
                 .Replace("{$Port}", target.Port.ToString())
-                .Replace("{$Username}", target.Username);
+                .Replace("{$Username}", target.Username)
+                .Replace("{$Options}", target.Options);
 
             var parts = exec.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
 
@@ -281,6 +282,7 @@ namespace sshhub
             Console.WriteLine("{$IP}\t\tConfigurated IP");
             Console.WriteLine("{$Port}\t\tConfigurated Port");
             Console.WriteLine("{$Username}\tConfigurated Username");
+            Console.WriteLine("{$Options}\tConfigurated other Options");
 
             string? input = Ask.String($"Current Exec ({Config.Exec})", checkEmpty: true);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-target “Target Options” when creating or editing connection targets.
  * Added support for the `{$Options}` placeholder in custom SSH command templates.
  * Displays each target’s configured options in target details.
  * Updated command template help to document `{$Options}`.
* **Bug Fixes / Improvements**
  * Added legacy configuration migration to automatically update outdated command templates that don’t include `{$Options}`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->